### PR TITLE
Rudimentary story delete functionality

### DIFF
--- a/client/reducers/_story.spec.js
+++ b/client/reducers/_story.spec.js
@@ -13,8 +13,20 @@ describe('Story Reducer', function() {
     defaultHint: 'my hint',
     clues: ['STORY:CLUE'],
   })
+  const startStory2 = Story.new({
+    uid: 'SECONDSTORY',
+    defaultHint: 'my hint',
+    clues: ['SECONDSTORY:CLUE'],
+  })
+  const startStory3 = Story.new({
+    uid: 'STORY2',
+    defaultHint: 'my hint',
+    clues: ['STORY2:CLUE'],
+  })
   const startStories = {
     [startStory.uid]: startStory,
+    [startStory2.uid]: startStory2,
+    [startStory3.uid]: startStory3
   }
 
   const newStory = Story.new({
@@ -49,6 +61,12 @@ describe('Story Reducer', function() {
         [startStory.uid]: {
           ...startStory,
           defaultHint: '42',
+        },
+        [startStory2.uid]: {
+          ...startStory2
+        },
+        [startStory3.uid]: {
+          ...startStory3
         }
       })
       expect(newState[startStory.uid]).not.to.equal(startStory)
@@ -61,6 +79,27 @@ describe('Story Reducer', function() {
       const action = setStory(newStory)
       const newState = reducer(startStories, action)
       expect(newState[startStory.uid]).to.eql(newStory)
+    });
+  });
+
+  describe(at.del(Story.type), function() {
+    it('should have the list minus the deleted item', function() {
+      const action = {type: at.del(Story.type), payload: {uid: startStory3.uid}}
+      const newState = reducer(startStories, action)
+      expect(newState).to.eql({
+        [startStory2.uid]: {
+          ...startStory2
+        },
+        [startStory.uid]: {
+          ...startStory
+        },
+      })
+    });
+
+    it('should delete the specific story deleted', function() {
+      const action = {type: at.del(Story.type), payload: {uid: startStory3.uid}}
+      const newState = reducer(startStories, action)
+      expect(newState).to.not.contain(startStory3)
     });
   });
 

--- a/client/reducers/_story.spec.js
+++ b/client/reducers/_story.spec.js
@@ -95,12 +95,6 @@ describe('Story Reducer', function() {
         },
       })
     });
-
-    it('should delete the specific story deleted', function() {
-      const action = {type: at.del(Story.type), payload: {uid: startStory3.uid}}
-      const newState = reducer(startStories, action)
-      expect(newState).to.not.contain(startStory3)
-    });
   });
 
   describe(at.set(Clue.type), function() {

--- a/client/reducers/story.js
+++ b/client/reducers/story.js
@@ -7,23 +7,27 @@ import commonReducer from './common'
 import { Story, Clue } from '../resources'
 import { splitUid } from '../utils'
 
+const transformClueUids = R.curry((fn, state, {payload}) => {
+  const {uid} = payload
+  const storyUid = splitUid(payload.uid).storyUid
+  return R.evolve({
+    [storyUid]: {
+      clues: fn(payload)
+    }
+  }, state)
+})
+
 export const DEFAULT_STATE = {}
 export default commonReducer(Story.type,
   handleActions({
-    [at.set(Clue.type)]: (stories, {payload}) => {
-      const storyUid = splitUid(payload.uid).storyUid
-      return R.evolve({
-        [storyUid]: {
-          clues: R.compose(R.uniq, R.append(payload.uid))
-        }
-      }, stories)},
-    [at.del(Clue.type)]: (stories, {payload}) => {
-      const storyUid = splitUid(payload.uid).storyUid
-      return R.evolve({
-        [storyUid]: {
-          clues: R.without(payload.uid)
-        }
-      }, stories)
-    },
+    [at.set(Clue.type)]: (
+      transformClueUids(({uid}) => R.compose(R.uniq, R.append(uid)))
+    ),
+    [at.del(Clue.type)]: (
+      transformClueUids(({uid}) => R.without(uid))
+    ),
+    [at.DROP_CLUE]: (
+      transformClueUids(({index, uid}) => R.compose(R.insert(index, uid), R.without(uid)))
+    ),
   }, DEFAULT_STATE)
 )

--- a/client/story/story.js
+++ b/client/story/story.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 
 import { uidsFromParams } from '../utils'
 import { getStory } from '../reducers'
-import { changeStory, saveStory } from '../actions'
+import { changeStory, saveStory, deleteStory } from '../actions'
 import { Clues } from '../clue'
 
 const stateToProps = (state, {params}) => {
@@ -13,7 +13,7 @@ const stateToProps = (state, {params}) => {
     story: getStory(state, storyUid),
   }
 }
-const Story = ({story, changeStory, saveStory}) => {
+const Story = ({story, changeStory, saveStory, deleteStory}) => {
   return (
     <section className="notification is-info">
       <h2> Story </h2>
@@ -21,6 +21,11 @@ const Story = ({story, changeStory, saveStory}) => {
         {story.uid}
       </h1>
       <div className="level">
+        <button
+          className="button is-danger level-item"
+          onClick={() => deleteStory(story.uid)}>
+          Delete
+        </button>
         <button
           className="button is-success level-item"
           onClick={() => saveStory(story.uid)}>
@@ -49,8 +54,10 @@ Story.propTypes = {
   story: React.PropTypes.object.isRequired,
   changeStory: React.PropTypes.func.isRequired,
   saveStory: React.PropTypes.func.isRequired,
+  deleteStory: React.PropTypes.func.isRequired,
 }
 export default connect(stateToProps, {
   changeStory,
-  saveStory
+  saveStory,
+  deleteStory
 })(Story)


### PR DESCRIPTION
Tests, along with basic ui and delete functionality added for stories.  Most of the work was already there so I just had to wire it up and write the tests.

Still missing better handling of delete ux (errors out and leaves you on the story editor vs going back to the story list - functions like an undo) and as well as general cleanup of the story list page.

@ChrisPenner let me know if this is ok for now or if the above should be resolved before this is merged.