### PR TITLE
Added extra props to story_code and some logic to populate them

### DIFF
--- a/server/app/models/story_code.py
+++ b/server/app/models/story_code.py
@@ -1,4 +1,5 @@
 import re
+import datetime
 from google.appengine.ext import ndb
 
 import wordcode
@@ -12,6 +13,9 @@ class StoryCode(ndb.Model):
     uid = ndb.ComputedProperty(lambda s: StoryCode.gen_key(s.word_string))
     used = ndb.BooleanProperty(default=False)
     single_use = ndb.BooleanProperty(default=False)
+    create_date = ndb.DateTimeProperty(auto_now_add=True)
+    used_date = ndb.DateTimeProperty(auto_now_add=False)
+    group_uid = ndb.StringProperty()
 
     @staticmethod
     def gen_key(words):
@@ -30,6 +34,11 @@ class StoryCode(ndb.Model):
         if self.single_use:
             self.used = True
             self.put()
+        #effectively last used for multi-use codes
+        self.used_date = datetime.datetime.now()
+
+    def set_group_uid(self, group_uid):
+        self.group_uid = group_uid
 
 
 def generate_codes(story_uid, amount, single_use):

--- a/server/app/scavenger.py
+++ b/server/app/scavenger.py
@@ -127,6 +127,7 @@ def start_story(message, user, group):
     if not start_clue:
         raise ValueError('Story {} has no clue named "START"'.format(story_code.story_uid))
     group_code = Group.gen_uid()
+    story_code.set_group_uid(group_code)
     group = Group.from_uid(group_code, clue_uid=start_clue.uid, story_uid=story_code.story_uid, user_keys=[user.key])
     return Result(
         response_type=INFO,


### PR DESCRIPTION
This should add the correct props to start tracking create and used dates for story codes as well as associate them with group_uids so that we can include a link directly from the story code UI to the group transcript. Multi-use codes could use some more work but I think this will help us troubleshoot in the case where WDM or someone else complains a specific code didn't work.